### PR TITLE
add back styling in action menu areas, fix silent update fail issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Fixed formating for time to match HH:MM:SS, before it would chop off MM and SS if was less then 10 (#74) PR #86
 - Fixed issue with insert error breaking the app. (#71) PR #87
 - Fixed issue with time, date, datetime, and timestamp display null as Nan::Nan, now it just display null for those fields (#75) PR #89
-- Fixed broken styling that came up in the code cleaning process.
+- Fixed broken styling that came up in the code cleaning process. PR #92
+- Fixed tinyInt input field min/max value. (#77) PR #92
 
 
 ## [0.1.0-alpha.2] - 2021-02-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Fixed formating for time to match HH:MM:SS, before it would chop off MM and SS if was less then 10 (#74) PR #86
 - Fixed issue with insert error breaking the app. (#71) PR #87
 - Fixed issue with time, date, datetime, and timestamp display null as Nan::Nan, now it just display null for those fields (#75) PR #89
+- Fixed broken styling that came up in the code cleaning process.
 
 
 ## [0.1.0-alpha.2] - 2021-02-19

--- a/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
@@ -188,8 +188,8 @@ class TableAttribute {
       // Determine type and any other attributes that need to be set based on that
       if (tableAttribute.attributeType === TableAttributeType.TINY) {
         type = "number";
-        min = "128";
-        max = "-127";
+        min = "-127";
+        max = "128";
       }
       else if (tableAttribute.attributeType === TableAttributeType.TINY_UNSIGNED) {
         type = "number";

--- a/src/Components/MainTableView/DeleteTuple/DeleteTuple.css
+++ b/src/Components/MainTableView/DeleteTuple/DeleteTuple.css
@@ -56,3 +56,13 @@ table.tupleToDelete tbody {
 .deleting button.dismiss:hover {
   background-color: rgb(212, 212, 212);
 }
+
+.confirmActionButton.delete {
+  border: 2px solid rgb(151, 0, 0);
+  color: rgb(151, 0, 0);
+}
+
+.confirmActionButton.delete:hover {
+  background-color: rgb(151, 0, 0);
+  color: white;
+}

--- a/src/Components/MainTableView/DeleteTuple/DeleteTuple.tsx
+++ b/src/Components/MainTableView/DeleteTuple/DeleteTuple.tsx
@@ -174,8 +174,8 @@ class DeleteTuple extends React.Component<{
             {this.getTableView()}
           </div>
           <div className="actionButtons">
-            <button className="confirmAction" onClick={() => this.handleTupleDeletion()} >Confirm Delete</button>
-            <button className="cancelAction" onClick={() => {this.setState({dependencies: []}); this.props.clearEntrySelection();}}>Cancel</button>
+            <button className="confirmActionButton delete" onClick={() => this.handleTupleDeletion()} >Confirm Delete</button>
+            <button className="cancelActionButton" onClick={() => {this.setState({dependencies: []}); this.props.clearEntrySelection();}}>Cancel</button>
           </div>
           <div className="deleting">
           {this.state.isDeletingEntry ? <p>Deleting entry might take a while...</p>: '' } {/* TODO: replace with proper animation */}

--- a/src/Components/MainTableView/InsertTuple/InsertTuple.css
+++ b/src/Components/MainTableView/InsertTuple/InsertTuple.css
@@ -26,20 +26,6 @@ form {
   color: rgb(5, 114, 5);
 }
 
-.submitButton {
-  margin-top: 16px;
-  border: 2px solid rgb(5, 114, 5);
-  padding: 8px 20px;
-  border-radius: 4px;
-  color: rgb(5, 114, 5);
-  cursor: pointer;
-}
-
-.submitButton:hover {
-  background-color: rgb(5, 114, 5);
-  color: white;
-}
-
 .copyOverPrompt {
   display: flex;
   align-items: center;

--- a/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
+++ b/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
@@ -238,7 +238,7 @@ class InsertTuple extends React.Component<{
             </div> :
             ''
           } 
-          <input className="submitButton" type='submit' value='Submit'></input>
+          <input className="confirmActionButton insert" type='submit' value='Insert'></input>
         </form>
         {this.state.errorMessage ? (
           <div>{this.state.errorMessage}<button className="dismiss" onClick={() => this.setState({errorMessage: ''})}>dismiss</button></div>

--- a/src/Components/MainTableView/TableContent.css
+++ b/src/Components/MainTableView/TableContent.css
@@ -162,29 +162,6 @@ table.table {
   text-overflow: ellipsis;
 }
 
-.nullableControls {
-  display: flex;
-  align-items: center;
-}
-
-.nullableTag {
-  color: white;
-  background-color: rgb(82, 82, 82);
-  border-radius: 4px;
-  font-size: 0.7rem;
-  margin: 0 4px;
-  padding: 2px 4px 1px;
-}
-
-.nullableControls .resetIcon {
-  color: rgb(82, 82, 82);
-  cursor: pointer;
-}
-
-.nullableControls .resetIcon:hover {
-  color: rgb(153, 153, 153);
-}
-
 div.cellDivider {
   position: absolute;
   width: 2px;

--- a/src/Components/MainTableView/TableView.css
+++ b/src/Components/MainTableView/TableView.css
@@ -81,7 +81,7 @@
   border-top: 1px solid gray;
   outline: none;
   height: 100%;
-  padding: 0 4px;
+  padding: 4px;
 }
 
 .fieldUnit input:disabled {
@@ -122,5 +122,59 @@
   display: flex;
   align-items: center;
   white-space: nowrap;
+  position: relative;
+  justify-content: space-between;
+}
 
+.nullableControls {
+  display: flex;
+  align-items: center;
+}
+
+.nullableTag {
+  color: white;
+  background-color: rgb(82, 82, 82);
+  border-radius: 4px;
+  font-size: 0.7rem;
+  margin: 0 4px;
+  padding: 2px 4px 1px;
+}
+
+.nullableControls .resetIcon {
+  color: rgb(82, 82, 82);
+  cursor: pointer;
+}
+
+.nullableControls .resetIcon:hover {
+  color: rgb(153, 153, 153);
+}
+
+/* change colors in each action css if necessary */
+.confirmActionButton {
+  margin-top: 16px;
+  border: 2px solid rgb(5, 114, 5);
+  padding: 8px 20px;
+  border-radius: 4px;
+  color: rgb(5, 114, 5);
+  cursor: pointer;
+}
+
+.confirmActionButton:hover {
+  background-color: rgb(5, 114, 5);
+  color: white;
+}
+
+.cancelActionButton {
+  margin-left: 8px;
+  margin-top: 16px;
+  border: 2px solid rgb(80, 80, 80);
+  padding: 8px 20px;
+  border-radius: 4px;
+  color: rgb(80, 80, 80);
+  cursor: pointer;
+}
+
+.cancelActionButton:hover {
+  background-color: rgb(80, 80, 80);
+  color: white;
 }

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.css
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.css
@@ -26,31 +26,13 @@ form {
   color: rgb(5, 114, 5);
 }
 
-.submitButton {
-  margin-top: 16px;
-  border: 2px solid rgb(5, 114, 5);
-  padding: 8px 20px;
-  border-radius: 4px;
-  color: rgb(5, 114, 5);
-  cursor: pointer;
+.confirmActionButton.update {
+  border: 2px solid rgb(189, 138, 28);
+  color: rgb(189, 138, 28);
 }
 
-.submitButton:hover {
-  background-color: rgb(5, 114, 5);
-  color: white;
-}
-
-.cancelButton {
-  margin-top: 16px;
-  border: 2px solid rgb(5, 114, 5);
-  padding: 8px 20px;
-  border-radius: 4px;
-  color: rgb(5, 114, 5);
-  cursor: pointer;
-}
-
-.cancelButton:hover {
-  background-color: rgb(5, 114, 5);
+.confirmActionButton.update:hover {
+  background-color: rgb(189, 138, 28);
   color: white;
 }
 

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
@@ -238,8 +238,8 @@ class UpdateTuple extends React.Component<{
               <div>
                 <p>Are you sure you want to submit form to update this entry?</p>
                 <div className="actionButtons">
-                  <input className="submitButton" type="submit" value="Submit"/>
-                  <button className="cancelButton" onClick={() => {this.setState({dependencies: []}); this.props.clearEntrySelection();}}>Cancel</button>
+                  <input className="confirmActionButton update" type="submit" value="Update"/>
+                  <button className="cancelActionButton update" onClick={() => {this.setState({dependencies: []}); this.props.clearEntrySelection();}}>Cancel</button>
                 </div>
               </div>
           </form>


### PR DESCRIPTION
- nullable tag area got fixed
- buttons now all styled
- adjust input area styling to match across

![image](https://user-images.githubusercontent.com/6288829/109364674-edf87080-7854-11eb-9b10-3fc7af0fa05e.png)

- resolve update fail bug by correcting the tinyInt field. Fixes #77