### PR TITLE
Nullable and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for double data type (#72) PR #86
 - Added search functionailty for table list similar to schema. (#73) PR #88
 - Added input field for date/datetime/time/timestamp copy over for insert and update. (#47) PR #87
+- Added support for reseting to null or default for insert and update (#48) PR #93
+- Added support to render default values if exist for insert (95) PR #93
 
 ### Changed
 - Changed dark and default logos to reflect new `DataJoint LabBook` name. PR #70
@@ -21,7 +23,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Fixed issue with time, date, datetime, and timestamp display null as Nan::Nan, now it just display null for those fields (#75) PR #89
 - Fixed broken styling that came up in the code cleaning process. PR #92
 - Fixed tinyInt input field min/max value. (#77) PR #92
-
 
 ## [0.1.0-alpha.2] - 2021-02-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Added search functionailty for table list similar to schema. (#73) PR #88
 - Added input field for date/datetime/time/timestamp copy over for insert and update. (#47) PR #87
 - Added support for reseting to null or default for insert and update (#48) PR #93
-- Added support to render default values if exist for insert (95) PR #93
+- Added support to render default values if exist for insert (#95) PR #93
 - Added browser default popup to confirm before page refresh. (#7) PR #94
 
 ### Changed

--- a/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
@@ -21,13 +21,14 @@ class SecondaryTableAttribute extends TableAttribute {
     ) {
     super(attributeName, attributeType, stringTypeAttributeLengthInfo, enumOptions, decimalNumDigits, decimalNumDecimalDigits);
     this.nullable = nullable;
-    this.defaultValue = defaultValue === null? undefined : defaultValue;
+    this.defaultValue = defaultValue === null || defaultValue === 'null' ? undefined : defaultValue;
   }
 
   static getAttributeLabelBlock(secondaryTableAttribute: SecondaryTableAttribute, resetToNullCallback: any) {
     const typeString = super.getTypeString(secondaryTableAttribute);
     var resetButtonText = 'nullable';
 
+    // I don't think this detects is correctly
     if (secondaryTableAttribute.defaultValue !== undefined) {
       resetButtonText = 'default';
     }

--- a/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
@@ -28,7 +28,6 @@ class SecondaryTableAttribute extends TableAttribute {
     const typeString = super.getTypeString(secondaryTableAttribute);
     var resetButtonText = 'nullable';
 
-    // I don't think this detects is correctly
     if (secondaryTableAttribute.defaultValue !== undefined) {
       resetButtonText = 'default';
     }

--- a/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/SecondaryTableAttribute.tsx
@@ -8,12 +8,12 @@ import {faRedoAlt} from '@fortawesome/free-solid-svg-icons'
  */
 class SecondaryTableAttribute extends TableAttribute {
   nullable: boolean;
-  defaultValue: string;
+  defaultValue?: string;
 
   constructor(attributeName: string,
     attributeType: TableAttributeType,
     nullable: boolean,
-    defaultValue: string,
+    defaultValue?: string,
     stringTypeAttributeLengthInfo?: number,
     enumOptions?: Array<string>,
     decimalNumDigits?: number,
@@ -21,23 +21,33 @@ class SecondaryTableAttribute extends TableAttribute {
     ) {
     super(attributeName, attributeType, stringTypeAttributeLengthInfo, enumOptions, decimalNumDigits, decimalNumDecimalDigits);
     this.nullable = nullable;
-    this.defaultValue = defaultValue;
+    this.defaultValue = defaultValue === null? undefined : defaultValue;
   }
 
   static getAttributeLabelBlock(secondaryTableAttribute: SecondaryTableAttribute, resetToNullCallback: any) {
     const typeString = super.getTypeString(secondaryTableAttribute);
+    var resetButtonText = 'nullable';
+
+    if (secondaryTableAttribute.defaultValue !== undefined) {
+      resetButtonText = 'default';
+    }
+    
     return(
       <div className="attributeHead">
         <label className="secondary-attribute-label" htmlFor={secondaryTableAttribute.attributeName}>{secondaryTableAttribute.attributeName + ' (' + typeString + ')'}</label>
         { 
-            secondaryTableAttribute.nullable ? 
+            secondaryTableAttribute.nullable || secondaryTableAttribute.defaultValue ? 
             <div className="nullableControls">
-              <div className="nullableTag">nullable</div>
+              <div className="nullableTag">{resetButtonText}</div>
               <FontAwesomeIcon className="resetIcon" icon={faRedoAlt} onClick={() => {resetToNullCallback(secondaryTableAttribute)}} />
             </div> : ''
         }
       </div>
     )
+  }
+
+  static getAttributeInputBlock(secondaryTableAttribute: SecondaryTableAttribute, currentValue: any, handleChange: any) {
+    return super.getAttributeInputBlock(secondaryTableAttribute, currentValue, secondaryTableAttribute.defaultValue, handleChange);
   }
 }
 

--- a/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
@@ -180,7 +180,7 @@ class TableAttribute {
      * @param defaultValue Any default value for input blocks that support it
      * @param handleChange Call back function for when the user make a change to the input block
      */
-    static getAttributeInputBlock(tableAttribute: TableAttribute, currentValue: any, defaultValue: string = "", handleChange: any) {
+    static getAttributeInputBlock(tableAttribute: TableAttribute, currentValue: any, defaultValue: string = '', handleChange: any) {
       let type: string = ""
       let min: string = "0";
       let max: string = "0";
@@ -302,28 +302,27 @@ class TableAttribute {
 
       }
       else if (tableAttribute.attributeType === TableAttributeType.DATE) {
-        return <input type="date" value={currentValue} defaultValue={defaultValue} id={tableAttribute.attributeName} onChange={(e) => handleChange(e, tableAttribute.attributeName)}></input>
+        return <input type="date" value={currentValue} defaultValue={defaultValue === '' ? undefined : defaultValue.replaceAll('"', "")} id={tableAttribute.attributeName} onChange={(e) => handleChange(e, tableAttribute.attributeName)}></input>
       }
       else if (tableAttribute.attributeType === TableAttributeType.DATETIME || tableAttribute.attributeType === TableAttributeType.TIMESTAMP) {
-        if (currentValue) {
-          const splitResult = currentValue.split(' ');
+        var splitResult = [undefined, undefined]
+        var defaultValueSplitResult: any = ['', '']
+
+        if (currentValue !== "undefined undefined") {
+          splitResult = currentValue.split(' ');
+        }
+
+        if (defaultValue !== undefined) {
+          defaultValueSplitResult = defaultValue.replaceAll('"', '').split(' ')
+        }
+        
           return(
             <div className="dateTimeFields">
               {/* <input type="datetime-local" value={currentValue.replace(',', ' ')} id={tableAttribute.attributeName} onChange={(e) => handleChange(e, tableAttribute.attributeName)} /> */}
-              <input type="date" defaultValue={splitResult[0]} id={tableAttribute.attributeName + "__date"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__date")}></input>
-              <input type="time" step="1" defaultValue={splitResult[1]} id={tableAttribute.attributeName + "__time"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__time")}></input>
+              <input type="date" defaultValue={defaultValueSplitResult[0]} value={splitResult[0]} id={tableAttribute.attributeName + "__date"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__date")}></input>
+              <input type="time" step="1" defaultValue={defaultValueSplitResult[1]} value={splitResult[1]} id={tableAttribute.attributeName + "__time"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__time")}></input>
             </div>
           );
-        }
-        else {
-          return(
-            <div className="dateTimeFields">
-              {/* <input type="datetime-local" value={defaultValue} id={tableAttribute.attributeName} onChange={(e) => handleChange(e, tableAttribute.attributeName)} /> */}
-              <input type="date" defaultValue={defaultValue} id={tableAttribute.attributeName + "__date"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__date")}></input>
-              <input type="time" step="1" defaultValue={defaultValue} id={tableAttribute.attributeName + "__time"} onChange={(e) => handleChange(e, tableAttribute.attributeName + "__time")}></input>
-            </div>
-          );
-        }
       }
       else if (tableAttribute.attributeType === TableAttributeType.TIME) {
         return <input type="text" value={currentValue} defaultValue={defaultValue} id={tableAttribute.attributeName} onChange={(e) => handleChange(e, tableAttribute.attributeName)}></input>

--- a/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
+++ b/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
@@ -138,7 +138,7 @@ class InsertTuple extends React.Component<{
       if (!tupleBuffer.hasOwnProperty(secondaryAttribute.attributeName)) {
         if (secondaryAttribute.nullable === true) {
           // Nullable is allow
-          tupleBuffer[secondaryAttribute.attributeName] = 'null';
+          delete tupleBuffer[secondaryAttribute.attributeName];
         }
         else if (secondaryAttribute.defaultValue !== null) {
           // Nullable is not allowed, but there is a default value
@@ -149,6 +149,9 @@ class InsertTuple extends React.Component<{
           this.setState({errorMessage: 'Missing require field: ' + secondaryAttribute.attributeName});
           return;
         }
+      }
+      else if (tupleBuffer[secondaryAttribute.attributeName] === '=NULL=') {
+        delete tupleBuffer[secondaryAttribute.attributeName];
       }
     }
 

--- a/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
+++ b/src/Components/MainTableView/InsertTuple/InsertTuple.tsx
@@ -43,6 +43,7 @@ class InsertTuple extends React.Component<{
     this.onSubmit = this.onSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.copyTuple = this.copyTuple.bind(this);
+    this.resetToNull = this.resetToNull.bind(this);
   }
 
   /**
@@ -184,11 +185,29 @@ class InsertTuple extends React.Component<{
    * TODO: Align behavior with the edge case specs - whether to null, or fill with default
    * @param tableAttribute Table attribute object so the function can extract the attributeName 
    */
-  resetToNull(tableAttribute: any) {
+  resetToNull(tableAttribute: SecondaryTableAttribute) {
     if (Object.entries(this.state.tupleBuffer).length) {
-      let updatedBuffer = Object.assign({}, this.state.tupleBuffer);
-      updatedBuffer[tableAttribute.attributeName] = tableAttribute.defaulValue; // set to defaulValue for now
-      this.setState({tupleBuffer: updatedBuffer});
+      let tupleBuffer = Object.assign({}, this.state.tupleBuffer);
+
+      if (tableAttribute.defaultValue !== undefined) {
+        if (tableAttribute.attributeType === TableAttributeType.DATE) {
+          tupleBuffer[tableAttribute.attributeName] = TableAttribute.covertRawDateToInputFieldFormat(tableAttribute.defaultValue);
+        }
+        else if (tableAttribute.attributeType === TableAttributeType.DATETIME) {
+          // Deal with date time string
+          const splitResult = tableAttribute.defaultValue.replaceAll('"', '').split(' ');
+          tupleBuffer[tableAttribute.attributeName + '__date'] = splitResult[0];
+          tupleBuffer[tableAttribute.attributeName + '__time'] = splitResult[1];
+        }
+        else {
+          tupleBuffer[tableAttribute.attributeName] = tableAttribute.defaultValue;
+        } 
+      }
+      else if (tableAttribute.nullable === true) {
+        tupleBuffer[tableAttribute.attributeName] = undefined;
+      }
+       // set to defaulValue for now
+      this.setState({tupleBuffer: tupleBuffer});
     }
   }
 
@@ -223,7 +242,12 @@ class InsertTuple extends React.Component<{
                 return(
                   <div className='fieldUnit' key={secondaryAttribute.attributeName}>
                     {SecondaryTableAttribute.getAttributeLabelBlock(secondaryAttribute, this.resetToNull)}
-                    {SecondaryTableAttribute.getAttributeInputBlock(secondaryAttribute, this.state.tupleBuffer[secondaryAttribute.attributeName], undefined, this.handleChange)}
+                    {SecondaryTableAttribute.getAttributeInputBlock(
+                      secondaryAttribute,
+                      secondaryAttribute.attributeType === TableAttributeType.DATETIME || secondaryAttribute.attributeType === TableAttributeType.TIMESTAMP?  
+                      this.state.tupleBuffer[secondaryAttribute.attributeName + '__date'] + ' ' + this.state.tupleBuffer[secondaryAttribute.attributeName + '__time'] :
+                        this.state.tupleBuffer[secondaryAttribute.attributeName], 
+                      this.handleChange)}
                   </div>
                 )
               })

--- a/src/Components/MainTableView/TableContent.tsx
+++ b/src/Components/MainTableView/TableContent.tsx
@@ -524,7 +524,6 @@ class TableContent extends React.Component<{token: string, selectedSchemaName: s
             : '' }
             </div>
         </div>
-
       </div>
     )
   }

--- a/src/Components/MainTableView/TableView.tsx
+++ b/src/Components/MainTableView/TableView.tsx
@@ -285,7 +285,6 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
           ));
       }
     }
-
     return tableAttributesInfo;
   }
 

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
@@ -142,7 +142,7 @@ class UpdateTuple extends React.Component<{
       if (!tupleBuffer.hasOwnProperty(secondaryAttribute.attributeName)) {
         if (secondaryAttribute.nullable === true) {
           // Nullable is allow
-          tupleBuffer[secondaryAttribute.attributeName] = 'null';
+          delete tupleBuffer[secondaryAttribute.attributeName];
         }
         else if (secondaryAttribute.defaultValue !== null) {
           // Nullable is not allowed, but there is a default value
@@ -153,6 +153,9 @@ class UpdateTuple extends React.Component<{
           this.setState({errorMessage: 'Missing require field: ' + secondaryAttribute.attributeName});
           return;
         }
+      }
+      else if (tupleBuffer[secondaryAttribute.attributeName] === '=NULL=') {
+        delete tupleBuffer[secondaryAttribute.attributeName];
       }
     }
 

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
@@ -75,7 +75,6 @@ class UpdateTuple extends React.Component<{
       return;
     } 
     else {
-      console.log(this.props.selectedTableEntry)
       this.setState({tupleBuffer: this.props.selectedTableEntry});
     }
   }

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
@@ -35,6 +35,7 @@ class UpdateTuple extends React.Component<{
 
     this.onSubmit = this.onSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.resetToNull = this.resetToNull.bind(this);
   }
 
    /**
@@ -74,6 +75,7 @@ class UpdateTuple extends React.Component<{
       return;
     } 
     else {
+      console.log(this.props.selectedTableEntry)
       this.setState({tupleBuffer: this.props.selectedTableEntry});
     }
   }
@@ -190,11 +192,29 @@ class UpdateTuple extends React.Component<{
    * TODO: Align behavior with the edge case specs - whether to null, or fill with default
    * @param tableAttribute Table attribute object so the function can extract the attributeName 
    */
-  resetToNull(tableAttribute: any) {
+  resetToNull(tableAttribute: SecondaryTableAttribute) {
     if (Object.entries(this.state.tupleBuffer).length) {
-      let updatedBuffer = Object.assign({}, this.state.tupleBuffer);
-      updatedBuffer[tableAttribute.attributeName] = tableAttribute.defaulValue; // set to defaulValue for now
-      this.setState({tupleBuffer: updatedBuffer});
+      let tupleBuffer = Object.assign({}, this.state.tupleBuffer);
+
+      if (tableAttribute.defaultValue !== undefined) {
+        if (tableAttribute.attributeType === TableAttributeType.DATE) {
+          tupleBuffer[tableAttribute.attributeName] = TableAttribute.covertRawDateToInputFieldFormat(tableAttribute.defaultValue);
+        }
+        else if (tableAttribute.attributeType === TableAttributeType.DATETIME) {
+          // Deal with date time string
+          const splitResult = tableAttribute.defaultValue.replaceAll('"', '').split(' ');
+          tupleBuffer[tableAttribute.attributeName + '__date'] = splitResult[0];
+          tupleBuffer[tableAttribute.attributeName + '__time'] = splitResult[1];
+        }
+        else {
+          tupleBuffer[tableAttribute.attributeName] = tableAttribute.defaultValue;
+        } 
+      }
+      else if (tableAttribute.nullable === true) {
+        tupleBuffer[tableAttribute.attributeName] = undefined;
+      }
+       // set to defaulValue for now
+      this.setState({tupleBuffer: tupleBuffer});
     }
   }
 
@@ -229,7 +249,12 @@ class UpdateTuple extends React.Component<{
                   return(
                     <div className='fieldUnit' key={secondaryAttribute.attributeName}>
                       {SecondaryTableAttribute.getAttributeLabelBlock(secondaryAttribute, this.resetToNull)}
-                      {SecondaryTableAttribute.getAttributeInputBlock(secondaryAttribute, this.state.tupleBuffer[secondaryAttribute.attributeName], undefined, this.handleChange)}
+                      {SecondaryTableAttribute.getAttributeInputBlock(
+                      secondaryAttribute,
+                      secondaryAttribute.attributeType === TableAttributeType.DATETIME || secondaryAttribute.attributeType === TableAttributeType.TIMESTAMP? 
+                      this.state.tupleBuffer[secondaryAttribute.attributeName + '__date'] + ' ' + this.state.tupleBuffer[secondaryAttribute.attributeName + '__time'] :
+                        this.state.tupleBuffer[secondaryAttribute.attributeName], 
+                      this.handleChange)}
                     </div>
                   )
                 })


### PR DESCRIPTION
- Redesign the way the input blocks and generated for datetime, timestamp, and date to handle default value and current state.
- Added support for reseting to null or default for insert and update (#48) PR #93
- Added support to render default values if exist for insert (#95) PR #93