### PR TITLE
Add refresh confirmation popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Changed Insert and Update component code to share common form generation code, still need to do for delete (#54) PR #86
 - Replaced the word delete with trash icon for filter card removal (#82) PR #87
 - Hide dependency logic in update and delete action - partially fixes (#83) PR #87 #91
+- Update nginx image to pull from datajoint organization. PR #94
 
 ### Fixed
 - Fixed issue with input fields for decimal, floats, and double not having the correct step settings. (#81) PR #86

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Support for double data type (#72) PR #86
 - Added search functionailty for table list similar to schema. (#73) PR #88
 - Added input field for date/datetime/time/timestamp copy over for insert and update. (#47) PR #87
+- Added browser default popup to confirm before page refresh. (#7) PR #94
 
 ### Changed
 - Changed dark and default logos to reflect new `DataJoint LabBook` name. PR #70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [Unreleased]
+## [0.1.0-beta.0] - 2021-02-26
 ### Added
 - Support for double data type (#72) PR #86
 - Added search functionailty for table list similar to schema. (#73) PR #88
@@ -36,5 +36,5 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Multi database server connections supported by opening new tabs.
 - Support of DJ NEURO - [Managed Database Hosting](https://djneuro.io/services/) users.
 
-[Unreleased]: https://github.com/datajoint/datajoint-labbook/compare/0.1.0-alpha.2...HEAD
+[0.1.0-beta.0]: https://github.com/datajoint/datajoint-labbook/compare/0.1.0-alpha.2...0.1.0-beta.0
 [0.1.0-alpha.2]: https://github.com/datajoint/datajoint-labbook/releases/tag/0.1.0-alpha.2

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -1,5 +1,5 @@
-# PHARUS_VERSION=0.1.0a5 DJLABBOOK_VERSION=0.1.0-alpha.2 docker-compose -f docker-compose-deploy.yaml pull
-# PHARUS_VERSION=0.1.0a5 DJLABBOOK_VERSION=0.1.0-alpha.2 docker-compose -f docker-compose-deploy.yaml up -d
+# PHARUS_VERSION=0.1.0b0 DJLABBOOK_VERSION=0.1.0-beta.0 docker-compose -f docker-compose-deploy.yaml pull
+# PHARUS_VERSION=0.1.0b0 DJLABBOOK_VERSION=0.1.0-beta.0 docker-compose -f docker-compose-deploy.yaml up -d
 #
 # Intended for production deployment.
 # Note: You must run both commands above for minimal outage.
@@ -21,7 +21,7 @@ services:
       - PHARUS_PORT=5000
   fakeservices.datajoint.io:
     <<: *net
-    image: raphaelguzman/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.15
     environment:
       - ADD_zlabbook_TYPE=STATIC
       - ADD_zlabbook_PREFIX=/

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -35,7 +35,7 @@ services:
         condition: service_healthy
   fakeservices.datajoint.io:
     <<: *net
-    image: raphaelguzman/nginx:v0.0.15
+    image: datajoint/nginx:v0.0.15
     environment:
       - ADD_zlabbook_TYPE=REST
       - ADD_zlabbook_ENDPOINT=datajoint-labbook:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "datajoint-labbook",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datajoint-labbook",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-beta.0",
   "description": "A frontend with graphical user interface for DataJoint pipelines built using React.",
   "private": false,
   "repository": {

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -7,7 +7,7 @@ import NavBar from './NavBar';
 import Login from './Login';
 import Home from './Home'
 
-if (window.performance && performance.navigation.type === 1) alert( "This page is reloaded" )
+window.onbeforeunload = () => '';
 
 type DJGUIAppState = {
   currentDatabaseConnectionJWT: string;

--- a/src/Components/App.tsx
+++ b/src/Components/App.tsx
@@ -7,6 +7,8 @@ import NavBar from './NavBar';
 import Login from './Login';
 import Home from './Home'
 
+if (window.performance && performance.navigation.type === 1) alert( "This page is reloaded" )
+
 type DJGUIAppState = {
   currentDatabaseConnectionJWT: string;
   hostname: string;


### PR DESCRIPTION
### Added
- Added browser default popup to confirm before page refresh. (#7) PR #94

### Changed
- Update nginx image to pull from datajoint organization. PR #94

Note: Also, updated `pharus` to latest `BETA` release and appropriate `BETA` version for `datajoint-labbook`.

![image](https://user-images.githubusercontent.com/38401847/109373121-a7197380-7872-11eb-98ca-e8e9cb10427c.png)

Fix #7