### PR TITLE
delete date/time format conversion fix, update primary field css 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - CSS for making the primary keys look disabled/readonly for update mode PR #105
 
 ### Fixed
-- Fix bug of delete with datetime in primarykey crashing PR#105
+- Fix bug of delete with datetime in primarykey crashing PR #105
 
 ## [0.1.0-beta.1] - 2021-02-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 
 ## [Unreleased]
 ### Added
-- CSS for making the primary keys look disabled/readonly for update mode PR#105
+- CSS for making the primary keys look disabled/readonly for update mode PR #105
 
 ### Fixed
 - Fix bug of delete with datetime in primarykey crashing PR#105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [Unreleased]
+### Added
+- CSS for making the primary keys look disabled/readonly for update mode PR#105
+
+### Fixed
+- Fix bug of delete with datetime in primarykey crashing PR#105
+
 ## [0.1.0-beta.1] - 2021-02-26
 ### Added
 - Support for double data type (#72) PR #86
@@ -47,5 +54,6 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Multi database server connections supported by opening new tabs.
 - Support of DJ NEURO - [Managed Database Hosting](https://djneuro.io/services/) users.
 
+[Unreleased]: https://github.com/datajoint/datajoint-labbook/compare/0.1.0-beta.1...HEAD
 [0.1.0-beta.1]: https://github.com/datajoint/datajoint-labbook/compare/0.1.0-alpha.2...0.1.0-beta.1
 [0.1.0-alpha.2]: https://github.com/datajoint/datajoint-labbook/releases/tag/0.1.0-alpha.2

--- a/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
@@ -308,7 +308,7 @@ class TableAttribute {
         var splitResult = [undefined, undefined]
         var defaultValueSplitResult: any = ['', '']
 
-        if (currentValue !== "undefined undefined") {
+        if (currentValue !== "undefined undefined" && currentValue !== undefined) {
           splitResult = currentValue.split(' ');
         }
 

--- a/src/Components/MainTableView/DeleteTuple/DeleteTuple.tsx
+++ b/src/Components/MainTableView/DeleteTuple/DeleteTuple.tsx
@@ -77,11 +77,11 @@ class DeleteTuple extends React.Component<{
     for (let primaryTableAttribute of this.props.tableAttributesInfo.primaryAttributes) {
       if (primaryTableAttribute.attributeType === TableAttributeType.DATE) {
         // Convert date to DJ date format
-        tupleToDelete[primaryTableAttribute.attributeName] = TableAttribute.parseDateToDJFormat(tupleToDelete[primaryTableAttribute.attributeName])
+        tupleToDelete[primaryTableAttribute.attributeName] = TableAttribute.parseDateToDJFormat(this.props.selectedTableEntry[primaryTableAttribute.attributeName])
       }
       else if (primaryTableAttribute.attributeType === TableAttributeType.DATETIME || primaryTableAttribute.attributeType === TableAttributeType.TIMESTAMP) {
         // Convert to DJ friendly datetime format
-        tupleToDelete[primaryTableAttribute.attributeName] = TableAttribute.parseDateTimeToDJFormat(tupleToDelete[primaryTableAttribute.attributeName])
+        tupleToDelete[primaryTableAttribute.attributeName] = TableAttribute.parseDateTimeToDJFormat(this.props.selectedTableEntry[primaryTableAttribute.attributeName])
       }
       else {
         tupleToDelete[primaryTableAttribute.attributeName] = this.props.selectedTableEntry[primaryTableAttribute.attributeName]

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.css
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.css
@@ -26,6 +26,11 @@ form {
   color: rgb(5, 114, 5);
 }
 
+.fieldUnit.primary input {
+  color: gray;
+  cursor: not-allowed;
+}
+
 .confirmActionButton.update {
   border: 2px solid rgb(189, 138, 28);
   color: rgb(189, 138, 28);

--- a/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
+++ b/src/Components/MainTableView/UpdateTuple/UpdateTuple.tsx
@@ -234,7 +234,7 @@ class UpdateTuple extends React.Component<{
                 // Deal with primary attirbutes
                 this.props.tableAttributesInfo?.primaryAttributes.map((primaryTableAttribute) => {
                   return(
-                    <div className='fieldUnit' key={primaryTableAttribute.attributeName}>
+                    <div className='fieldUnit primary' key={primaryTableAttribute.attributeName}>
                       {PrimaryTableAttribute.getAttributeLabelBlock(primaryTableAttribute)}
                       {PrimaryTableAttribute.getAttributeInputBlock(primaryTableAttribute, this.state.tupleBuffer[primaryTableAttribute.attributeName], this.handleChange)}
                     </div>


### PR DESCRIPTION
- make sure selected entries with date/time as primary field get converted correctly in delete mode.
![Screenshot Mar-02-2021 11-14-22](https://user-images.githubusercontent.com/6288829/109687165-9a35a200-7b48-11eb-8c5c-12c9975c02fd.gif)

- update css for update mode where primary field doesn't look like it's editable.
![screenshot Mar-02-2021 11-18-47](https://user-images.githubusercontent.com/6288829/109687691-1cbe6180-7b49-11eb-964c-b28de923b2f1.gif)
