### PR TITLE
Pageination rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Case invariate behavior to schema and table search box (#99) PR #102
 - Added Case insensitive behavior to schema and table search box (#99) PR #102
 - CSS for making the primary keys look disabled/readonly for update mode PR #105
+- Added number of tuples input box for fetch table viewing PR #117
 
 ### Fixed
-- Fix bug of delete with datetime in primarykey crashing PR #105
+- Fixed bug of delete with datetime in primarykey crashing PR #105
+- Fixed broken pageing system for fetching tuples. Before it was fetching everything, now it doesn't and fetch what is only needed (#30) PR #117
+- Fixed redundent data fetching when user switch between Table Content and Table Info PR #117
+- Fixed redundent props to state copy in tableInfo component PR #117
 
 ## [0.1.0-beta.1] - 2021-02-26
 ### Added

--- a/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
+++ b/src/Components/MainTableView/DataStorageClasses/TableAttribute.tsx
@@ -348,8 +348,7 @@ class TableAttribute {
                 return(<option selected={currentValue === enumOptionString} key={enumOptionString} value={enumOptionString}>{enumOptionString}</option>);
               })}
             </select>
-        )
-        }
+        )}
       }
   
       // Handle number return types

--- a/src/Components/MainTableView/Filter/Filter.tsx
+++ b/src/Components/MainTableView/Filter/Filter.tsx
@@ -16,7 +16,7 @@ type FilterState = {
 /**
  * Filter component that is in charge of managing one to many FilterCards as well as the data store beind them
  */
-class Filter extends React.Component<{tableAttributesInfo?: TableAttributesInfo, fetchTableContent: any}, FilterState> {
+class Filter extends React.Component<{tableAttributesInfo?: TableAttributesInfo, setRestrictions: (restrictions: Array<Restriction>) => void}, FilterState> {
   constructor(props: any) {
     super(props);
     this.state = {
@@ -114,7 +114,7 @@ class Filter extends React.Component<{tableAttributesInfo?: TableAttributesInfo,
 
       // Call fetch content if there is at lesat one valid restriction
       if (validRestrictions.length >= 0) {
-        this.props.fetchTableContent(validRestrictions);
+        this.props.setRestrictions(validRestrictions);
       }
     }, 1000);
 

--- a/src/Components/MainTableView/TableContent.css
+++ b/src/Components/MainTableView/TableContent.css
@@ -206,3 +206,13 @@ input[type="checkbox"][disabled] {
   color: rgb(196, 196, 196);
   cursor: not-allowed;
 }
+
+.number-of-rows-per-page-input {
+  display: flex;
+  flex-direction: row;
+}
+
+.number-of-rows-per-page-input input{
+  margin-left: 20px;
+  width: 40px;
+}

--- a/src/Components/MainTableView/TableContent.tsx
+++ b/src/Components/MainTableView/TableContent.tsx
@@ -10,7 +10,7 @@ import DeleteTuple from './DeleteTuple/DeleteTuple'
 import TableAttributesInfo from './DataStorageClasses/TableAttributesInfo';
 import TableAttribute from './DataStorageClasses/TableAttribute'
 import TableAttributeType from './enums/TableAttributeType'
-import { convertToObject } from 'typescript';
+import Restriction from './DataStorageClasses/Restriction'
 
 enum PaginationCommand {
   FORWARD,
@@ -63,7 +63,8 @@ class TableContent extends React.Component<{
     tableAttributesInfo?: TableAttributesInfo,
     setPageNumber: any,
     setNumberOfTuplesPerPage: any,
-    fetchTableContent: any}, 
+    fetchTableContent: any,
+    setRestrictions: (restrictions: Array<Restriction>) => void},
   TableContentStatus> {
   constructor(props: any) {
     super(props);
@@ -148,7 +149,7 @@ class TableContent extends React.Component<{
       return (<div className="actionMenuContainer">
           <Filter 
             tableAttributesInfo={this.props.tableAttributesInfo}
-            fetchTableContent={this.props.fetchTableContent}
+            setRestrictions={this.props.setRestrictions}
           />
         </div>)
     }

--- a/src/Components/MainTableView/TableContent.tsx
+++ b/src/Components/MainTableView/TableContent.tsx
@@ -85,7 +85,7 @@ class TableContent extends React.Component<{
     this.goToFirstPage = this.goToFirstPage.bind(this);
     this.goToLastPage = this.goToLastPage.bind(this);
     this.goForwardAPage = this.goForwardAPage.bind(this);
-    this.goToLastPage = this.goToLastPage.bind(this);
+    this.goBackwardAPage = this.goBackwardAPage.bind(this);
     this.handleNumberOfTuplesPerPageChange = this.handleNumberOfTuplesPerPageChange.bind(this);
   }
 

--- a/src/Components/MainTableView/TableContent.tsx
+++ b/src/Components/MainTableView/TableContent.tsx
@@ -128,11 +128,16 @@ class TableContent extends React.Component<{
   }
 
   goForwardAPage() {
-    this.props.setPageNumber(this.props.currentPageNumber + 1);
+    if (this.props.currentPageNumber != this.props.maxPageNumber) {
+      this.props.setPageNumber(this.props.currentPageNumber + 1);
+    }
+    
   }
 
   goBackwardAPage() {
-    this.props.setPageNumber(this.props.currentPageNumber - 1);
+    if (this.props.currentPageNumber != 1) {
+      this.props.setPageNumber(this.props.currentPageNumber - 1);
+    } 
   }
 
   /**
@@ -472,7 +477,7 @@ class TableContent extends React.Component<{
                 <div className="controls">
                   <FontAwesomeIcon className={true ? "backAll icon" : "backAll icon disabled"} icon={faStepBackward} onClick={() => this.goToFirstPage()} />
                   <FontAwesomeIcon className={true  ? "backOne icon" : "backOne icon disabled"} icon={faChevronLeft} onClick={() => this.goBackwardAPage()} />
-                  Page: {this.props.currentPageNumber}
+                  Page: ({this.props.currentPageNumber + ' / ' + this.props.maxPageNumber})
                   <FontAwesomeIcon className={true  ? "forwardOne icon" : "forwardOne icon disabled"} icon={faChevronRight} onClick={() => this.goForwardAPage()} />
                   <FontAwesomeIcon className={true  ? "forwardAll icon" : "forwardAll icon disabled"} icon={faStepForward} onClick={() => this.goToLastPage()} />
                 </div>

--- a/src/Components/MainTableView/TableContent.tsx
+++ b/src/Components/MainTableView/TableContent.tsx
@@ -59,8 +59,10 @@ class TableContent extends React.Component<{
     totalNumOfTuples: number,
     currentPageNumber: number,
     maxPageNumber: number,
+    tuplePerPage: number,
     tableAttributesInfo?: TableAttributesInfo,
     setPageNumber: any,
+    setNumberOfTuplesPerPage: any,
     fetchTableContent: any}, 
   TableContentStatus> {
   constructor(props: any) {
@@ -84,6 +86,7 @@ class TableContent extends React.Component<{
     this.goToLastPage = this.goToLastPage.bind(this);
     this.goForwardAPage = this.goForwardAPage.bind(this);
     this.goToLastPage = this.goToLastPage.bind(this);
+    this.handleNumberOfTuplesPerPageChange = this.handleNumberOfTuplesPerPageChange.bind(this);
   }
 
   /**
@@ -125,7 +128,6 @@ class TableContent extends React.Component<{
   }
 
   goForwardAPage() {
-    console.log('asdjfklasjdlkfj')
     this.props.setPageNumber(this.props.currentPageNumber + 1);
   }
 
@@ -241,6 +243,10 @@ class TableContent extends React.Component<{
     // Covert array into object
 
     this.setState({selectedTupleIndex: tupleIndex, selectedTuple: tupleBuffer});
+  }
+
+  handleNumberOfTuplesPerPageChange(event: any) {
+    this.props.setNumberOfTuplesPerPage(event.target.value)
   }
 
   /**
@@ -458,6 +464,10 @@ class TableContent extends React.Component<{
           </div>
             <div className="paginator">
               <p>Total Table Entries: {this.props.totalNumOfTuples}</p>
+              <div className="number-of-rows-per-page-input">
+                <p>Number of row per page</p>
+                <input type='number' value={this.props.tuplePerPage} onChange={this.handleNumberOfTuplesPerPageChange}></input>
+              </div>
               {Object.entries(this.props.contentData).length ?
                 <div className="controls">
                   <FontAwesomeIcon className={true ? "backAll icon" : "backAll icon disabled"} icon={faStepBackward} onClick={() => this.goToFirstPage()} />

--- a/src/Components/MainTableView/TableInfo.tsx
+++ b/src/Components/MainTableView/TableInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import './TableInfo.css';
 
 type TableInfoState = {
-  tableDefinition: string
 }
 
 class TableInfo extends React.Component<{infoDefData: string}, TableInfoState> {
@@ -13,19 +12,12 @@ class TableInfo extends React.Component<{infoDefData: string}, TableInfoState> {
     }
   }
 
-  componentDidUpdate(prevProps: any, prevState: any) {
-    if (this.props.infoDefData !== prevState.tableDefinition) {
-      this.setState({tableDefinition: this.props.infoDefData});
-
-    }
-  }
-
   render() {
     return (
       <div className="table-info-viewer">
         <div className="info-content">
           <h4 className="info-title">Description</h4>
-          <div className="description-info">{this.state.tableDefinition}</div>
+          <div className="description-info">{this.props.infoDefData}</div>
         </div>
       </div>
     )

--- a/src/Components/MainTableView/TableInfo.tsx
+++ b/src/Components/MainTableView/TableInfo.tsx
@@ -7,9 +7,6 @@ type TableInfoState = {
 class TableInfo extends React.Component<{infoDefData: string}, TableInfoState> {
   constructor(props: any) {
     super(props);
-    this.state = {
-      tableDefinition: ''
-    }
   }
 
   render() {

--- a/src/Components/MainTableView/TableView.css
+++ b/src/Components/MainTableView/TableView.css
@@ -111,9 +111,6 @@
   font-weight: bolder;
 }
 
-.secondary-attribute-label {
-}
-
 .attributeHead {
   display: table-cell;
   padding: 4px;

--- a/src/Components/MainTableView/TableView.tsx
+++ b/src/Components/MainTableView/TableView.tsx
@@ -91,8 +91,12 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
         this.setState({tableDefinitionNeedRefresh: false})
       }
     }
-    else if (this.state.currentPageNumber !== prevState.currentPageNumber || this.state.numberOfTuplesPerPage != prevState.numberOfTuplesPerPage) {
+    else if (this.state.currentPageNumber !== prevState.currentPageNumber) {
       this.fetchTableContent();
+    }
+    else if (this.state.numberOfTuplesPerPage != prevState.numberOfTuplesPerPage) {
+      this.fetchTableContent();
+      this.setState({currentPageNumber: 1}); // Reset back to the first page
     }
   }
 
@@ -249,7 +253,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
         }
       }
 
-      this.setState({tableContentData: result.tuples, totalNumOfTuples: result.total_count, errorMessage: '', maxPageNumber:  Math.ceil(this.state.totalNumOfTuples / this.state.numberOfTuplesPerPage), isLoading: false})
+      this.setState({tableContentData: result.tuples, totalNumOfTuples: result.total_count, errorMessage: '', maxPageNumber:  Math.ceil(result.total_count / this.state.numberOfTuplesPerPage), isLoading: false})
     })
     .catch(error => {
       this.setState({tableContentData: [], errorMessage: 'Problem fetching table content: ' + error, isLoading: false})
@@ -258,8 +262,9 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
 
   setPageNumber(pageNumber: number) {
     console.log(pageNumber)
+    console.log(this.state.maxPageNumber);
     if (pageNumber < 1 || pageNumber > this.state.maxPageNumber) {
-      throw Error('Invalid pageNumber requested');
+      throw Error('Invalid pageNumber ' + pageNumber + ' requested');
     }
 
     this.setState({currentPageNumber: pageNumber});

--- a/src/Components/MainTableView/TableView.tsx
+++ b/src/Components/MainTableView/TableView.tsx
@@ -24,7 +24,7 @@ type TableViewState = {
   currentView: CurrentView,
   tableContentNeedRefresh: boolean,
   tableDefinitionNeedRefresh: boolean,
-  tuplePerPage: number,
+  numberOfTuplesPerPage: number,
   totalNumOfTuples: number,
   currentPageNumber: number,
   maxPageNumber: number,
@@ -42,7 +42,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
       currentView: CurrentView.TABLE_CONTENT,
       tableContentNeedRefresh: true,
       tableDefinitionNeedRefresh: true,
-      tuplePerPage: 25,
+      numberOfTuplesPerPage: 25,
       currentPageNumber: 1,
       maxPageNumber: 1,
       tableContentData: [],
@@ -54,6 +54,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
 
     this.fetchTableAttributeAndContent = this.fetchTableAttributeAndContent.bind(this);
     this.setPageNumber = this.setPageNumber.bind(this);
+    this.setNumberOfTuplesPerPage = this.setNumberOfTuplesPerPage.bind(this);
     this.fetchTableContent = this.fetchTableContent.bind(this);
   }
 
@@ -90,7 +91,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
         this.setState({tableDefinitionNeedRefresh: false})
       }
     }
-    else if (this.state.currentPageNumber !== prevState.currentPageNumber) {
+    else if (this.state.currentPageNumber !== prevState.currentPageNumber || this.state.numberOfTuplesPerPage != prevState.numberOfTuplesPerPage) {
       this.fetchTableContent();
     }
   }
@@ -163,7 +164,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
     
 
     // Add limit to url
-    urlParams.push('limit=' + this.state.tuplePerPage);
+    urlParams.push('limit=' + this.state.numberOfTuplesPerPage);
 
     // Add page param
     urlParams.push('page=' + this.state.currentPageNumber);
@@ -248,7 +249,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
         }
       }
 
-      this.setState({tableContentData: result.tuples, totalNumOfTuples: result.total_count, errorMessage: '', maxPageNumber:  Math.ceil(this.state.totalNumOfTuples / this.state.tuplePerPage), isLoading: false})
+      this.setState({tableContentData: result.tuples, totalNumOfTuples: result.total_count, errorMessage: '', maxPageNumber:  Math.ceil(this.state.totalNumOfTuples / this.state.numberOfTuplesPerPage), isLoading: false})
     })
     .catch(error => {
       this.setState({tableContentData: [], errorMessage: 'Problem fetching table content: ' + error, isLoading: false})
@@ -262,6 +263,10 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
     }
 
     this.setState({currentPageNumber: pageNumber});
+  }
+
+  setNumberOfTuplesPerPage(numberOfTuplesPerPage: number) {
+    this.setState({numberOfTuplesPerPage: numberOfTuplesPerPage});
   }
  
   /**
@@ -488,8 +493,10 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
                 currentPageNumber = {this.state.currentPageNumber}
                 maxPageNumber = {this.state.maxPageNumber}
                 totalNumOfTuples = {this.state.totalNumOfTuples}
+                tuplePerPage = {this.state.numberOfTuplesPerPage}
                 tableAttributesInfo = {this.state.tableAttributesInfo}
                 setPageNumber = {this.setPageNumber}
+                setNumberOfTuplesPerPage = {this.setNumberOfTuplesPerPage}
                 fetchTableContent = {this.fetchTableContent}
             />
           )

--- a/src/Components/MainTableView/TableView.tsx
+++ b/src/Components/MainTableView/TableView.tsx
@@ -14,6 +14,8 @@ import Restriction from './DataStorageClasses/Restriction';
 import { faTemperatureHigh } from '@fortawesome/free-solid-svg-icons';
 import { url } from 'inspector';
 
+const NUMBER_OF_TUPLES_PER_PAGE_TIMEOUT: number = 500;
+
 enum CurrentView {
   TABLE_CONTENT,
   TABLE_INFO
@@ -25,6 +27,7 @@ type TableViewState = {
   tableContentNeedRefresh: boolean,
   tableDefinitionNeedRefresh: boolean,
   numberOfTuplesPerPage: number,
+  setNumberOFTuplesPerPageTimeout: ReturnType<typeof setTimeout>
   totalNumOfTuples: number,
   currentPageNumber: number,
   maxPageNumber: number,
@@ -43,6 +46,7 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
       tableContentNeedRefresh: true,
       tableDefinitionNeedRefresh: true,
       numberOfTuplesPerPage: 25,
+      setNumberOFTuplesPerPageTimeout: setTimeout(() => {}, 1000),
       currentPageNumber: 1,
       maxPageNumber: 1,
       tableContentData: [],
@@ -95,8 +99,11 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
       this.fetchTableContent();
     }
     else if (this.state.numberOfTuplesPerPage != prevState.numberOfTuplesPerPage) {
-      this.fetchTableContent();
-      this.setState({currentPageNumber: 1}); // Reset back to the first page
+      clearTimeout(this.state.setNumberOFTuplesPerPageTimeout);
+      const setNumberOFTuplesPerPageTimeout = setTimeout(() => {
+        this.fetchTableContent();
+        this.setState({currentPageNumber: 1});
+      }, NUMBER_OF_TUPLES_PER_PAGE_TIMEOUT)
     }
   }
 
@@ -261,8 +268,6 @@ class TableView extends React.Component<{token: string, selectedSchemaName: stri
   }
 
   setPageNumber(pageNumber: number) {
-    console.log(pageNumber)
-    console.log(this.state.maxPageNumber);
     if (pageNumber < 1 || pageNumber > this.state.maxPageNumber) {
       throw Error('Invalid pageNumber ' + pageNumber + ' requested');
     }

--- a/src/Components/SideMenu/TableList.tsx
+++ b/src/Components/SideMenu/TableList.tsx
@@ -183,7 +183,6 @@ class TableList extends React.Component<{token: string, tableListDict: any, sele
           }
         }
       }
-
       this.setState({searchString: event.target.value, restrictedTableList: restrictedTableList});
     }
     else {


### PR DESCRIPTION
Depends on #106 

- Pagenation now works properly and no longer fetches the entire table which is extremely wasteful
- Switching between tablecontent and tableinfo now doens't trigger a fetch if there is no need to
- Added a input field for how many tuples the user wants to display on their screen (default is still 25)
- Some code clean up such as removing unecessary copys of props to state when the variables can just be used from props directly

![image](https://user-images.githubusercontent.com/10690095/110040227-0e6a7400-7d08-11eb-8b37-c79d9754b95c.png)
![image](https://user-images.githubusercontent.com/10690095/110040279-28a45200-7d08-11eb-925d-710c2cd9d926.png)
